### PR TITLE
added goal 'compile-directory'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.9</version>
         <configuration>
           <excludePackageNames>com.google.*:org.apache.*:org.codehaus.*:javax.*:com.sun.*</excludePackageNames>
           <tags>

--- a/protostuff-maven-plugin/README.md
+++ b/protostuff-maven-plugin/README.md
@@ -1,0 +1,87 @@
+# Protostuff Maven Plugin
+
+Maven plugin to execute the protostuff compiler to create java classes from *.proto files. 
+ 
+## Getting started
+
+There are two goals to invoke the plugin. 
+
+### compile goal 
+
+The <code>compile</code> goal allows you to invoke the plugin with detailed configuration about your proto files.
+
+- it is possible to configure the input using the following configuration tags:
+
+```xml
+        <configuration>
+          <protoModules>
+            <protoModule>
+              <source>src/main/resources/foo.proto</source>
+              <outputDir>src/main/java</outputDir>
+              <output>java_bean</output>
+              <encoding>UTF-8</encoding>
+              <options>
+                <property>
+                  <name>generate_field_map</name>
+                </property>
+              </options>
+            </protoModule>
+          </protoModules>
+        </configuration>   
+```
+
+- or using a property file for the compiler, adding the filepath to the plugin like this:
+
+```xml
+<configuration>
+	<modulesFile>./src/main/resources/config.properties</modulesFile>
+</configuration>
+```
+
+More information to the compile goal are available [here](https://code.google.com/p/protostuff/wiki/CompilerViaMaven) on the project site.
+
+### compile-directory goal
+			
+For being able to compile all "proto" files of certain directories, you can use the <code>compile-directory</code> goal.
+This is how it would look like:   
+
+```xml
+				<executions>
+					<execution>
+						<id>generate-protobuf-sources</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>compile-directory</goal>
+						</goals>
+						<configuration>
+							<outputBaseDir>${project.build.generatedSourceOutput}/protostuff</outputBaseDir>
+							<protoDirectory>
+								<pathToProtoDirectories>
+									<pathToProtoDirectory>${project.build.sourceDirectory}/../proto</pathToProtoDirectory>
+								</pathToProtoDirectories>
+								<output>java_bean</output>
+							</protoDirectory>
+						</configuration>
+					</execution>
+				</executions>
+```
+
+The outputBaseDir tag points to the root directory, in which the java classes will be created. The default value is <code>${project.build.Directory}/generated-sources/protostuff</code>.
+(For inserting the classes afterwards in the build process, you need to invoke the "add-source" goal of the build helper plugin with the apropriate path.)
+
+The pathToProtoDirectories tag can be filled with subtags containing a directory path. All files with the extention .proto in this folder will be compiled to
+the outputBaseDir. 
+
+The output tag indicates possible types of the output, the default value is set to <code>java_bean</code>. Look at the [plugin site](https://code.google.com/p/protostuff/wiki/CompilerViaMaven) to
+know, which one to use best!  
+
+## Colophon		
+
+### Contributers
+This maven plugin was created as a part of [protostuff](https://code.google.com/p/protostuff/).
+
+The compile-directory goal was added by Dan Häberlein, [TIQ-Solutions](www.tiq-solutions.com), Germany.
+
+### License 
+   
+All changes made are licensed under [Apache License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0). 

--- a/protostuff-maven-plugin/pom.xml
+++ b/protostuff-maven-plugin/pom.xml
@@ -62,6 +62,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+		<groupId>org.apache.maven.shared</groupId>
+		<artifactId>maven-plugin-testing-harness</artifactId>
+		<version>1.1</version>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.codehaus.plexus</groupId>
+		<artifactId>plexus-utils</artifactId>
+		<version>3.0.10</version>
+		<scope>test</scope>
+	</dependency>
+    <dependency>
       <groupId>com.dyuproject.protostuff</groupId>
       <artifactId>protostuff-codegen</artifactId>
       <version>${project.version}</version>

--- a/protostuff-maven-plugin/src/main/java/com/dyuproject/protostuff/mojo/ProtoCompilerDirMojo.java
+++ b/protostuff-maven-plugin/src/main/java/com/dyuproject/protostuff/mojo/ProtoCompilerDirMojo.java
@@ -1,0 +1,187 @@
+//========================================================================
+//Copyright 2007-2010 David Yu dyuproject@gmail.com
+//Copyright 2013 Dan Häberlein dan.haeberlein@tiq-solutions.de
+//------------------------------------------------------------------------
+//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//You may obtain a copy of the License at 
+//http://www.apache.org/licenses/LICENSE-2.0
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+//========================================================================
+
+package com.dyuproject.protostuff.mojo;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.project.MavenProject;
+
+import com.dyuproject.protostuff.compiler.CompilerMain;
+
+/**
+ * Compiles proto files to java/gwt/etc.
+ * 
+ * @author Dan Häberlein
+ * @created May 08, 2013
+ * @goal compile-directory
+ * @phase generate-sources
+ * @requiresDependencyResolution runtime
+ */
+public class ProtoCompilerDirMojo extends AbstractMojo {
+
+	/**
+	 * The current Maven project.
+	 * 
+	 * @parameter default-value="${project}"
+	 * @readonly
+	 * @required
+	 * @since 1.0.1
+	 */
+	private MavenProject project;
+
+	/**
+	 * When {@code true}, skip the execution.
+	 * 
+	 * @parameter expression="${protostuff.compiler.skip}" default-value="false"
+	 * @since 1.0.1
+	 */
+	private boolean skip;
+
+	/**
+	 * Usually most of protostuff mojos will not get executed on parent poms
+	 * (i.e. projects with packaging type 'pom'). Setting this parameter to
+	 * {@code true} will force the execution of this mojo, even if it would
+	 * usually get skipped in this case.
+	 * 
+	 * @parameter expression="${protostuff.compiler.force}"
+	 *            default-value="false"
+	 * @required
+	 * @since 1.0.1
+	 */
+	private boolean forceMojoExecution;
+
+	/**
+	 * Config for using a directory which contains .proto files. They
+	 * will be compiled into outputBaseDir.
+	 * 
+	 * @parameter
+	 * @since 1.0.8
+	 */
+	private ProtoDirConfig protoDirectory;
+
+	/**
+	 * If not specified, the directory
+	 * "${project.build.directory}/generated-sources/protostuff" will be used as
+	 * its base dir.
+	 * 
+	 * This is only relevent when {@link #modulesFile is provided}.
+	 * 
+	 * @parameter
+	 * @since 1.0.8
+	 */
+	private File outputBaseDir;
+
+	public void execute() throws MojoExecutionException, MojoFailureException {
+		if (!skipMojo()) {
+			try {
+				setDefaultOutputDirectory();
+				initDirectoryListWhenEmpty();
+				createProtobufsUsingDirs();
+			} catch (Exception e) {
+				throw new MojoExecutionException(e.getMessage(), e);
+			}
+		}
+	}
+
+	private void setDefaultOutputDirectory() {
+		if (outputBaseDir == null)
+			outputBaseDir = new File(project.getBuild().getDirectory() + "/generated-sources/protostuff");
+	}
+
+	private void initDirectoryListWhenEmpty() {
+		boolean pathDirIsNull = protoDirectory.getPathToProtoDirectories() == null;
+		if (pathDirIsNull) {
+			protoDirectory.setPathToProtoDirectories(Collections.<String>emptyList());
+		}
+	}
+
+	private void createProtobufsUsingDirs() throws Exception {
+		List<String> pathToProtoDirectories = protoDirectory.getPathToProtoDirectories();
+		for (String currentPathToProto : pathToProtoDirectories) {
+			File currentFileHandlerToProto = new File(currentPathToProto);
+			boolean exists = currentFileHandlerToProto.exists();
+			boolean isDir = currentFileHandlerToProto.isDirectory();
+			if (exists && isDir) {
+				compileContainingProtoFiles(currentFileHandlerToProto);
+			} else {
+				printWarnMessage(currentFileHandlerToProto, exists, isDir);
+			}
+		}
+	}
+
+	private void compileContainingProtoFiles(File currentMojoDir) throws Exception {
+		File[] filesList = currentMojoDir.listFiles(new ProtoFileFilter());
+		for (File currentProtoFile : filesList) {
+			com.dyuproject.protostuff.compiler.ProtoModule module = new com.dyuproject.protostuff.compiler.ProtoModule(currentProtoFile,
+					protoDirectory.getOutput(), "UTF-8", outputBaseDir);
+			CompilerMain.compile(module);
+		}
+	}
+
+	private void printWarnMessage(File currentMojoDir, boolean exists, boolean isDir) throws IOException {
+		StringBuilder warnMessageSb = new StringBuilder();
+		warnMessageSb.append("given path ");
+		warnMessageSb.append(currentMojoDir.getCanonicalPath().toString());
+		warnMessageSb.append(" is not valid. reason:\n");
+		warnMessageSb.append("exits " + exists);
+		warnMessageSb.append("\nis directory " + isDir);
+		getLog().warn(warnMessageSb.toString());
+	}
+
+	/**
+	 * <p>
+	 * Determine if the mojo execution should get skipped.
+	 * </p>
+	 * This is the case if:
+	 * <ul>
+	 * <li>{@link #skip} is <code>true</code></li>
+	 * <li>if the mojo gets executed on a project with packaging type 'pom' and
+	 * {@link #forceMojoExecution} is <code>false</code></li>
+	 * </ul>
+	 * 
+	 * @return <code>true</code> if the mojo execution should be skipped.
+	 * @since 1.0.1
+	 */
+	protected boolean skipMojo() {
+		if (skip) {
+			getLog().info("Skipping protostuff mojo execution");
+			return true;
+		}
+
+		if (!forceMojoExecution && project != null  && "pom".equals(project.getPackaging())) {
+			getLog().info("Skipping protostuff mojo execution for project with packaging type 'pom'");
+			return true;
+		}
+
+		return false;
+	}
+
+	private static class ProtoFileFilter implements FileFilter {
+
+		private static final String PROTOBUF_FILE_EXTENTION = ".proto";
+
+		public boolean accept(File pathname) {
+			return pathname.getName().endsWith(PROTOBUF_FILE_EXTENTION);
+		}
+	}
+}

--- a/protostuff-maven-plugin/src/main/java/com/dyuproject/protostuff/mojo/ProtoDirConfig.java
+++ b/protostuff-maven-plugin/src/main/java/com/dyuproject/protostuff/mojo/ProtoDirConfig.java
@@ -1,0 +1,30 @@
+package com.dyuproject.protostuff.mojo;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class ProtoDirConfig implements Serializable {
+
+	private static final long serialVersionUID = 5547658091474270213L;
+	
+	private List<String> pathToProtoDirectories;
+	private String output = "java_bean";
+	
+	public List<String> getPathToProtoDirectories() {
+		return pathToProtoDirectories;
+	}
+	
+	public void setPathToProtoDirectories(List<String> pathToProtoDirectories) {
+		this.pathToProtoDirectories = pathToProtoDirectories;
+	}
+		
+	public String getOutput() {
+		return output;
+	}
+	
+	public void setOutput(String output) {
+		this.output = output;
+	}
+	
+	public ProtoDirConfig() {}
+}

--- a/protostuff-maven-plugin/src/main/java/com/dyuproject/protostuff/mojo/ProtoDirConfig.java
+++ b/protostuff-maven-plugin/src/main/java/com/dyuproject/protostuff/mojo/ProtoDirConfig.java
@@ -7,8 +7,20 @@ public class ProtoDirConfig implements Serializable {
 
 	private static final long serialVersionUID = 5547658091474270213L;
 	
+	/**
+	 * searchablePaths
+	 */
 	private List<String> pathToProtoDirectories;
+	
+	/**
+	 * Output format of the protostuff compiler
+	 */
 	private String output = "java_bean";
+	
+	/**
+	 * Search for .proto files in subdirs (default=false)
+	 */
+	private boolean recursive;
 	
 	public List<String> getPathToProtoDirectories() {
 		return pathToProtoDirectories;
@@ -26,5 +38,13 @@ public class ProtoDirConfig implements Serializable {
 		this.output = output;
 	}
 	
+	public boolean isRecursive() {
+		return recursive;
+	}
+
+	public void setRecursive(boolean recursive) {
+		this.recursive = recursive;
+	}
+
 	public ProtoDirConfig() {}
 }

--- a/protostuff-maven-plugin/src/test/java/com/dyuproject/protostuff/mojo/TestProtoCompilerMojo.java
+++ b/protostuff-maven-plugin/src/test/java/com/dyuproject/protostuff/mojo/TestProtoCompilerMojo.java
@@ -94,6 +94,23 @@ public class TestProtoCompilerMojo extends AbstractMojoTestCase {
 		assertTrue(files.isEmpty());
 	}
 	
+	public void testRecursive() throws Exception {
+		executeMavenPlugin(POM_FIXTURE_DIR + "/proto_directory/recursive_option/pom_rec.xml");
+		Set<String> expectedPaths = new HashSet<String>();
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","tutorial","AddressBook.java"));
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","tutorial","Name.java"));
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","tutorial","Person.java"));
+		checkGeneratedClasses(expectedPaths);
+	}
+	
+	public void testNonRecursive() throws Exception {
+		executeMavenPlugin(POM_FIXTURE_DIR + "/proto_directory/recursive_option/pom_non_rec.xml");
+		Set<String> expectedPaths = new HashSet<String>();
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","tutorial","AddressBook.java"));
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","tutorial","Person.java"));
+		checkGeneratedClasses(expectedPaths);
+	}
+	
 	private void executeMavenPlugin(String pomLocation) throws Exception, MojoExecutionException, MojoFailureException {
 		executeMavenPlugin(pomLocation, DEFAULT_BASEDIR);
 	}
@@ -133,6 +150,18 @@ public class TestProtoCompilerMojo extends AbstractMojoTestCase {
 		assertEquals(expectedPaths.size(), i);
 	}
 	
+	private boolean valueContainedInPrefixSet(Set<String> prefixValues, String value){
+		boolean found = false;
+		if(prefixValues != null)
+			for(String currentPrefix : prefixValues){
+				if(value.endsWith(currentPrefix)){
+					found = true;
+					break;
+				}
+			}
+		return found;
+	}
+	
 	private List<File> getFilesFromDirs(File fileHandlerWorkingDir) {
 		List<File> foundFiles = new ArrayList<File>();
 		if (fileHandlerWorkingDir != null && fileHandlerWorkingDir.exists()) {
@@ -151,18 +180,6 @@ public class TestProtoCompilerMojo extends AbstractMojoTestCase {
 			}
 		}
 		return foundFiles;
-	}
-
-	private boolean valueContainedInPrefixSet(Set<String> prefixValues, String value){
-		boolean found = false;
-		if(prefixValues != null)
-			for(String currentPrefix : prefixValues){
-				if(value.endsWith(currentPrefix)){
-					found = true;
-					break;
-				}
-			}
-		return found;
 	}
 
 }

--- a/protostuff-maven-plugin/src/test/java/com/dyuproject/protostuff/mojo/TestProtoCompilerMojo.java
+++ b/protostuff-maven-plugin/src/test/java/com/dyuproject/protostuff/mojo/TestProtoCompilerMojo.java
@@ -1,0 +1,168 @@
+package com.dyuproject.protostuff.mojo;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+
+import com.dyuproject.protostuff.mojo.stubs.ProtostuffMavenPluginStub;
+
+public class TestProtoCompilerMojo extends AbstractMojoTestCase {
+
+	private static final String DEFAULT_BASEDIR = "./target/test-harness/protostuff";
+	private static final String POM_FIXTURE_DIR = "src/test/resources/project-to-test";
+	private static final String GOAL = "compile-directory";
+
+	private String FILE_SEPARATOR = System.getProperty("file.separator");
+
+	private File fileHandlerWorkingDir;
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		fileHandlerWorkingDir = new File(DEFAULT_BASEDIR);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		try {
+			deleteFromDirRecursively(fileHandlerWorkingDir);
+		} catch (Exception e) {
+			System.err.println("cant't delete files");
+			e.printStackTrace();
+		}
+
+	}
+	
+	private void deleteFromDirRecursively(File fileHandlerWorkingDir) {
+		if (fileHandlerWorkingDir != null && fileHandlerWorkingDir.exists() && fileHandlerWorkingDir.isDirectory()) {
+			File[] folderContent = fileHandlerWorkingDir.listFiles();
+			for (File currentFile : folderContent) {
+				if (currentFile.isFile()) {
+					currentFile.delete();
+				} else {
+					deleteFromDirRecursively(currentFile);
+					currentFile.delete();
+				}
+			}
+		}
+	}
+	
+	/*
+	 * Tests 
+	 */
+
+	// protoDirectory Tests
+	
+	public void testBuildingProtosFromMultipleDirectories() throws Exception {
+		executeMavenPlugin(POM_FIXTURE_DIR + "/proto_directory/multiple_dir/pom.xml");
+		Set<String> expectedPaths = new HashSet<String>();
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","foo","Person.java"));
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","tutorial","AddressBook.java"));
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","tutorial","Name.java"));
+		expectedPaths.add(createFileSeparatorString("protostuff", "com","example","tutorial","Person.java"));
+		checkGeneratedClasses(expectedPaths);
+	}
+	
+	public void testBuildingProtosUsingDifferentOutputDirectory() throws Exception {
+		executeMavenPlugin(POM_FIXTURE_DIR + "/proto_directory/default_dir/pom.xml");
+		Set<String> expectedPaths = new HashSet<String>();
+		expectedPaths.add(createFileSeparatorString("target", "generated-sources", "protostuff", "com","example","foo","Person.java"));
+		expectedPaths.add(createFileSeparatorString("target", "generated-sources", "protostuff", "com","example","tutorial","AddressBook.java"));
+		expectedPaths.add(createFileSeparatorString("target", "generated-sources", "protostuff", "com","example","tutorial","Name.java"));
+		expectedPaths.add(createFileSeparatorString("target", "generated-sources", "protostuff", "com","example","tutorial","Person.java"));
+		checkGeneratedClasses(expectedPaths);
+	}
+	
+	public void testBuildingProtosUsingDefaultOutput() throws Exception {
+		executeMavenPlugin(POM_FIXTURE_DIR + "/proto_directory/default_output/pom.xml");
+		Set<String> expectedPaths = new HashSet<String>();
+		expectedPaths.add(createFileSeparatorString("com","example","foo","Person.java"));
+		checkGeneratedClasses(expectedPaths);
+	}
+	
+	public void testBuildingProtosWithoutInput() throws Exception {
+		executeMavenPlugin(POM_FIXTURE_DIR + "/proto_directory/empty_proto_directory/pom.xml");
+		List<File> files = getFilesFromDirs(fileHandlerWorkingDir);
+		assertTrue(files.isEmpty());
+	}
+	
+	private void executeMavenPlugin(String pomLocation) throws Exception, MojoExecutionException, MojoFailureException {
+		executeMavenPlugin(pomLocation, DEFAULT_BASEDIR);
+	}
+	
+	private void executeMavenPlugin(String pomLocation, String baseDir) throws Exception, MojoExecutionException, MojoFailureException {
+		File pom = getTestFile(pomLocation);
+		assertNotNull(pom);
+		assertTrue(pom.exists());
+		ProtoCompilerDirMojo pcMojo = (ProtoCompilerDirMojo) lookupMojo(GOAL, pom);
+		setVariableValueToObject(pcMojo, "project", new ProtostuffMavenPluginStub(pomLocation, baseDir));
+		assertNotNull(pcMojo);
+		pcMojo.execute();
+	}
+	
+	private String createFileSeparatorString(String... values) {
+		StringBuilder sb = new StringBuilder("");
+		if (values.length > 0) {
+			for (int i = 0; i < values.length - 1; i++) {
+				sb.append(values[i]).append(FILE_SEPARATOR);
+			}
+			sb.append(values[values.length - 1]);
+		}
+		return sb.toString();
+	}
+
+	private void checkGeneratedClasses(Set<String> expectedPaths) throws IOException{
+		checkGeneratedClasses(expectedPaths, fileHandlerWorkingDir);
+	}
+	
+	private void checkGeneratedClasses(Set<String> expectedPaths, File fileHandler) throws IOException {
+		List<File> createdJavaClasses = getFilesFromDirs(fileHandler);
+		int i = 0;
+		for (; i < createdJavaClasses.size(); i++) {
+			String pathToCreatedJavaFile = createdJavaClasses.get(i).getCanonicalPath();
+			assertTrue(pathToCreatedJavaFile + "was not created during the build process", valueContainedInPrefixSet(expectedPaths, pathToCreatedJavaFile));
+		}
+		assertEquals(expectedPaths.size(), i);
+	}
+	
+	private List<File> getFilesFromDirs(File fileHandlerWorkingDir) {
+		List<File> foundFiles = new ArrayList<File>();
+		if (fileHandlerWorkingDir != null && fileHandlerWorkingDir.exists()) {
+			if (fileHandlerWorkingDir.isDirectory()) {
+				File[] folderContent = fileHandlerWorkingDir.listFiles();
+				for (File currentFile : folderContent) {
+					if (currentFile.isFile()) {
+						foundFiles.add(currentFile);
+					} else {
+						foundFiles.addAll(getFilesFromDirs(currentFile));
+					}
+				}
+
+			} else {
+				foundFiles.add(fileHandlerWorkingDir);
+			}
+		}
+		return foundFiles;
+	}
+
+	private boolean valueContainedInPrefixSet(Set<String> prefixValues, String value){
+		boolean found = false;
+		if(prefixValues != null)
+			for(String currentPrefix : prefixValues){
+				if(value.endsWith(currentPrefix)){
+					found = true;
+					break;
+				}
+			}
+		return found;
+	}
+
+}

--- a/protostuff-maven-plugin/src/test/java/com/dyuproject/protostuff/mojo/stubs/ProtostuffMavenPluginStub.java
+++ b/protostuff-maven-plugin/src/test/java/com/dyuproject/protostuff/mojo/stubs/ProtostuffMavenPluginStub.java
@@ -1,0 +1,91 @@
+package com.dyuproject.protostuff.mojo.stubs;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.apache.maven.settings.Settings;
+import org.codehaus.plexus.util.ReaderFactory;
+
+public class ProtostuffMavenPluginStub extends MavenProjectStub {
+
+	private File baseDir;
+	private Model model;
+	private String pomLocation;
+
+	public ProtostuffMavenPluginStub(String pomLocation, String baseDir) {
+		this.pomLocation = pomLocation;
+		this.baseDir = new File(baseDir);
+		model = createPomModel();
+		setProjectInfos();
+		setDirectoryPaths();
+		setSrcPaths();
+	}
+
+	private Model createPomModel() {
+		Model model;
+		try {
+			MavenXpp3Reader pomReader = new MavenXpp3Reader();
+			model = pomReader.read(ReaderFactory.newXmlReader(new File(pomLocation)));
+			setModel(model);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		return model;
+	}
+
+	private void setProjectInfos() {
+		setGroupId(model.getGroupId());
+		setArtifactId(model.getArtifactId());
+		setVersion(model.getVersion());
+		setName(model.getName());
+		setUrl(model.getUrl());
+		setPackaging(model.getPackaging());
+	}
+
+	private void setDirectoryPaths() {
+		Build build = new Build();
+		build.setFinalName(model.getArtifactId());
+		build.setDirectory(getBasedir() + "/target");
+		build.setSourceDirectory(getBasedir() + "/src/main/java");
+		build.setOutputDirectory(getBasedir() + "/target/classes");
+		build.setTestSourceDirectory(getBasedir() + "/src/test/java");
+		build.setTestOutputDirectory(getBasedir() + "/target/test-classes");
+		model.setBuild(build);
+	}
+
+	private void setSrcPaths() {
+		List<String> compileSourceRoots = new ArrayList<String>();
+		compileSourceRoots.add(getBasedir() + "/src/main/java");
+		setCompileSourceRoots(compileSourceRoots);
+
+		List<String> testCompileSourceRoots = new ArrayList<String>();
+		testCompileSourceRoots.add(getBasedir() + "/src/test/java");
+		setTestCompileSourceRoots(testCompileSourceRoots);
+	}
+
+	@Override
+	public File getBasedir() {
+		return baseDir;
+	}
+
+	@Override
+	public Build getBuild() {
+		return model.getBuild();
+	}
+
+	public class SettingsStub extends Settings {
+
+		private static final long serialVersionUID = 8210937661580151495L;
+
+		/** {@inheritDoc} */
+		public List<?> getProxies() {
+			return Collections.EMPTY_LIST;
+		}
+	}
+}

--- a/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/default_dir/pom.xml
+++ b/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/default_dir/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>protostuff-maven-plugin-test-1</artifactId>
+	<groupId>com.dyuproject.protostuff</groupId>
+	<name>test generate proto classes using a set of directories</name>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>protostuff-maven-plugin</artifactId>
+				<groupId>com.dyuproject.protostuff</groupId>
+				<version>1.0.9-SNAPSHOT</version>
+				<configuration>
+					<protoDirectory>
+						<pathToProtoDirectories>
+							<pathToProtoDirectory>./src/test/resources/proto/fixture1</pathToProtoDirectory>
+							<pathToProtoDirectory>./src/test/resources/proto/fixture2</pathToProtoDirectory>
+						</pathToProtoDirectories>
+						<output>java_bean</output>
+					</protoDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/default_output/pom.xml
+++ b/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/default_output/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>protostuff-maven-plugin-test-1</artifactId>
+	<groupId>com.dyuproject.protostuff</groupId>
+	<name>test generate proto classes using a set of directories</name>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>protostuff-maven-plugin</artifactId>
+				<groupId>com.dyuproject.protostuff</groupId>
+				<version>1.0.9-SNAPSHOT</version>
+				<configuration>
+					<outputBaseDir>target/test-harness/protostuff</outputBaseDir>
+					<protoDirectory>
+						<pathToProtoDirectories>
+							<pathToProtoDirectory>./src/test/resources/proto/fixture1</pathToProtoDirectory>
+						</pathToProtoDirectories>
+					</protoDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/empty_proto_directory/pom.xml
+++ b/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/empty_proto_directory/pom.xml
@@ -1,0 +1,35 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>protostuff-maven-plugin-test-1</artifactId>
+	<groupId>com.dyuproject.protostuff</groupId>
+	<name>test generate proto classes using a set of directories</name>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>protostuff-maven-plugin</artifactId>
+				<groupId>com.dyuproject.protostuff</groupId>
+				<version>1.0.9-SNAPSHOT</version>
+				<configuration>
+					<outputBaseDir>target/test-harness/protostuff</outputBaseDir>
+					<protoDirectory>
+						<pathToProtoDirectories>
+						</pathToProtoDirectories>
+						<output>java_bean</output>
+					</protoDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/multiple_dir/pom.xml
+++ b/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/multiple_dir/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>protostuff-maven-plugin-test-1</artifactId>
+	<groupId>com.dyuproject.protostuff</groupId>
+	<name>test generate proto classes using a set of directories</name>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>protostuff-maven-plugin</artifactId>
+				<groupId>com.dyuproject.protostuff</groupId>
+				<version>1.0.9-SNAPSHOT</version>
+				<configuration>
+					<outputBaseDir>target/test-harness/protostuff</outputBaseDir>
+					<protoDirectory>
+						<pathToProtoDirectories>
+							<pathToProtoDirectory>./src/test/resources/proto/fixture1</pathToProtoDirectory>
+							<pathToProtoDirectory>./src/test/resources/proto/fixture2</pathToProtoDirectory>
+						</pathToProtoDirectories>
+						<output>java_bean</output>
+					</protoDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/recursive_option/pom_non_rec.xml
+++ b/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/recursive_option/pom_non_rec.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>protostuff-maven-plugin-test-1</artifactId>
+	<groupId>com.dyuproject.protostuff</groupId>
+	<name>test generate proto classes using a set of directories</name>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>protostuff-maven-plugin</artifactId>
+				<groupId>com.dyuproject.protostuff</groupId>
+				<version>1.0.9-SNAPSHOT</version>
+				<configuration>
+					<outputBaseDir>target/test-harness/protostuff</outputBaseDir>
+					<protoDirectory>
+						<pathToProtoDirectories>
+							<pathToProtoDirectory>./src/test/resources/proto/fixture3</pathToProtoDirectory>
+						</pathToProtoDirectories>
+						<output>java_bean</output>
+					</protoDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/recursive_option/pom_rec.xml
+++ b/protostuff-maven-plugin/src/test/resources/project-to-test/proto_directory/recursive_option/pom_rec.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                      http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>protostuff-maven-plugin-test-1</artifactId>
+	<groupId>com.dyuproject.protostuff</groupId>
+	<name>test generate proto classes using a set of directories</name>
+	<version>0.0.1-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<dependencies>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>protostuff-maven-plugin</artifactId>
+				<groupId>com.dyuproject.protostuff</groupId>
+				<version>1.0.9-SNAPSHOT</version>
+				<configuration>
+					<outputBaseDir>target/test-harness/protostuff</outputBaseDir>
+					<protoDirectory>
+						<pathToProtoDirectories>
+							<pathToProtoDirectory>./src/test/resources/proto/fixture3</pathToProtoDirectory>
+						</pathToProtoDirectories>
+						<output>java_bean</output>
+						<recursive>true</recursive>
+					</protoDirectory>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/protostuff-maven-plugin/src/test/resources/proto/fixture1/foo.proto
+++ b/protostuff-maven-plugin/src/test/resources/proto/fixture1/foo.proto
@@ -1,0 +1,15 @@
+package foo;
+
+option optimize_for = LITE_RUNTIME;
+option java_package = "com.example.foo";
+
+message Person {
+  required int32 id = 1;
+  optional string name = 2;
+  optional string motto = 3 [default="When the cat is away, the mouse is alone!"];
+  enum Gender {
+    MALE = 1;
+    FEMALE = 2;
+  }
+  optional Gender gender = 4;
+}

--- a/protostuff-maven-plugin/src/test/resources/proto/fixture1/test.txt
+++ b/protostuff-maven-plugin/src/test/resources/proto/fixture1/test.txt
@@ -1,0 +1,1 @@
+no proto file - fixture for unit tests

--- a/protostuff-maven-plugin/src/test/resources/proto/fixture2/name.proto
+++ b/protostuff-maven-plugin/src/test/resources/proto/fixture2/name.proto
@@ -1,0 +1,10 @@
+package tutorial;
+
+option java_package = "com.example.tutorial";
+option java_outer_classname = "NamePojo";
+
+message Name {
+  required string firstName = 1;
+  required string lastName = 2;
+  optional string middleName = 3;
+}

--- a/protostuff-maven-plugin/src/test/resources/proto/fixture2/person.proto
+++ b/protostuff-maven-plugin/src/test/resources/proto/fixture2/person.proto
@@ -1,0 +1,27 @@
+package tutorial;
+
+option java_package = "com.example.tutorial";
+option java_outer_classname = "AddressBookProtos";
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    required string number = 1;
+    optional PhoneType type = 2 [default = HOME];
+  }
+
+  repeated PhoneNumber phone = 4;
+}
+
+message AddressBook {
+  repeated Person person = 1;
+}

--- a/protostuff-maven-plugin/src/test/resources/proto/fixture3/person.proto
+++ b/protostuff-maven-plugin/src/test/resources/proto/fixture3/person.proto
@@ -1,0 +1,27 @@
+package tutorial;
+
+option java_package = "com.example.tutorial";
+option java_outer_classname = "AddressBookProtos";
+
+message Person {
+  required string name = 1;
+  required int32 id = 2;
+  optional string email = 3;
+
+  enum PhoneType {
+    MOBILE = 0;
+    HOME = 1;
+    WORK = 2;
+  }
+
+  message PhoneNumber {
+    required string number = 1;
+    optional PhoneType type = 2 [default = HOME];
+  }
+
+  repeated PhoneNumber phone = 4;
+}
+
+message AddressBook {
+  repeated Person person = 1;
+}

--- a/protostuff-maven-plugin/src/test/resources/proto/fixture3/subfolder/name.proto
+++ b/protostuff-maven-plugin/src/test/resources/proto/fixture3/subfolder/name.proto
@@ -1,0 +1,10 @@
+package tutorial;
+
+option java_package = "com.example.tutorial";
+option java_outer_classname = "NamePojo";
+
+message Name {
+  required string firstName = 1;
+  required string lastName = 2;
+  optional string middleName = 3;
+}


### PR DESCRIPTION
Dear Protostuffers, 

for some of our projects we needed the functionallity to compile all proto files in a certain directory(ies). So I decided to add a maven mojo, which provides this functionality, binded to a new goal. 
The new existing goal is called "compile-directory". I find the changes really useful and I hope that you'll integrate them into the project. 
At this point, thanks to your effort creating protostuff - it is an amazing project.
If there are any questions about the code, I will try to answer them.

Best regards - D. Häberlein, TIQ Solutions
